### PR TITLE
String Escapes

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -106,7 +106,7 @@ static void skipWhitespaceBefore(Lexer* lexer) {
 }
 
 static Token string(Lexer* lexer) {
-	while (peek(lexer) != '"' && !isAtEnd(lexer)) {
+	while (!(peek(lexer) == '"' && lexer->current[-1] != '\\') && !isAtEnd(lexer)) {
 		if (peek(lexer) == '\n') lexer->line++;
 		advance(lexer);
 	}


### PR DESCRIPTION
Adds support for the basic string escapes, including:
 - `\b`
 - `\f`
 - `\n`
 - `\r`
 - `\t`
 - `\v`
 - `\\`
 - `\'`
 - `\"`
 - `\0`
For use within string literals.